### PR TITLE
#12 Add pull to refresh support to bookmarks screen 

### DIFF
--- a/app/src/main/java/com/koalatea/sedaily/feature/bookmarks/BookmarksFragment.kt
+++ b/app/src/main/java/com/koalatea/sedaily/feature/bookmarks/BookmarksFragment.kt
@@ -62,7 +62,7 @@ class BookmarksFragment : BaseFragment() {
             epoxyRecyclerView.setController(this)
         }
 
-        swipeRefreshLayoutBookmarks.setOnRefreshListener {
+        bookmarksSwipeRefreshLayout.setOnRefreshListener {
             viewModel.fetchBookmarks()
         }
 
@@ -98,18 +98,18 @@ class BookmarksFragment : BaseFragment() {
 
     private fun showLoading() {
         emptyStateContainer.visibility = View.GONE
-        swipeRefreshLayoutBookmarks.visibility = View.GONE
+        bookmarksSwipeRefreshLayout.visibility = View.GONE
 
-        swipeRefreshLayoutBookmarks.isRefreshing = true
+        bookmarksSwipeRefreshLayout.isRefreshing = true
     }
 
     private fun hideLoading() {
-        swipeRefreshLayoutBookmarks.isRefreshing = false
+        bookmarksSwipeRefreshLayout.isRefreshing = false
     }
 
     private fun showLoginEmptyState() {
-        swipeRefreshLayoutBookmarks.visibility = View.GONE
-        swipeRefreshLayoutBookmarks.isRefreshing = false
+        bookmarksSwipeRefreshLayout.visibility = View.GONE
+        bookmarksSwipeRefreshLayout.isRefreshing = false
 
         emptyStateContainer.textView.text = getString(R.string.login_to_manage_bookmarks)
         emptyStateContainer.visibility = View.VISIBLE
@@ -119,9 +119,9 @@ class BookmarksFragment : BaseFragment() {
         bookmarksEpoxyController?.setData(episodes)
 
         emptyStateContainer.visibility = View.GONE
-        swipeRefreshLayoutBookmarks.isRefreshing = false
+        bookmarksSwipeRefreshLayout.isRefreshing = false
 
-        swipeRefreshLayoutBookmarks.visibility = View.VISIBLE
+        bookmarksSwipeRefreshLayout.visibility = View.VISIBLE
     }
 
 }

--- a/app/src/main/java/com/koalatea/sedaily/feature/bookmarks/BookmarksFragment.kt
+++ b/app/src/main/java/com/koalatea/sedaily/feature/bookmarks/BookmarksFragment.kt
@@ -62,6 +62,10 @@ class BookmarksFragment : BaseFragment() {
             epoxyRecyclerView.setController(this)
         }
 
+        swipeRefreshLayoutBookmarks.setOnRefreshListener {
+            viewModel.fetchBookmarks()
+        }
+
         viewModel.bookmarksResource.observe(this, Observer { resource ->
             when (resource) {
                 is Resource.Loading -> {
@@ -96,16 +100,16 @@ class BookmarksFragment : BaseFragment() {
         emptyStateContainer.visibility = View.GONE
         epoxyRecyclerView.visibility = View.GONE
 
-        progressBar.visibility = View.VISIBLE
+        swipeRefreshLayoutBookmarks.isRefreshing = true
     }
 
     private fun hideLoading() {
-        progressBar.visibility = View.GONE
+        swipeRefreshLayoutBookmarks.isRefreshing = false
     }
 
     private fun showLoginEmptyState() {
         epoxyRecyclerView.visibility = View.GONE
-        progressBar.visibility = View.GONE
+        swipeRefreshLayoutBookmarks.isRefreshing = false
 
         emptyStateContainer.textView.text = getString(R.string.login_to_manage_bookmarks)
         emptyStateContainer.visibility = View.VISIBLE
@@ -115,7 +119,7 @@ class BookmarksFragment : BaseFragment() {
         bookmarksEpoxyController?.setData(episodes)
 
         emptyStateContainer.visibility = View.GONE
-        progressBar.visibility = View.GONE
+        swipeRefreshLayoutBookmarks.isRefreshing = false
 
         epoxyRecyclerView.visibility = View.VISIBLE
     }

--- a/app/src/main/java/com/koalatea/sedaily/feature/bookmarks/BookmarksFragment.kt
+++ b/app/src/main/java/com/koalatea/sedaily/feature/bookmarks/BookmarksFragment.kt
@@ -98,7 +98,7 @@ class BookmarksFragment : BaseFragment() {
 
     private fun showLoading() {
         emptyStateContainer.visibility = View.GONE
-        epoxyRecyclerView.visibility = View.GONE
+        swipeRefreshLayoutBookmarks.visibility = View.GONE
 
         swipeRefreshLayoutBookmarks.isRefreshing = true
     }
@@ -108,7 +108,7 @@ class BookmarksFragment : BaseFragment() {
     }
 
     private fun showLoginEmptyState() {
-        epoxyRecyclerView.visibility = View.GONE
+        swipeRefreshLayoutBookmarks.visibility = View.GONE
         swipeRefreshLayoutBookmarks.isRefreshing = false
 
         emptyStateContainer.textView.text = getString(R.string.login_to_manage_bookmarks)
@@ -121,7 +121,7 @@ class BookmarksFragment : BaseFragment() {
         emptyStateContainer.visibility = View.GONE
         swipeRefreshLayoutBookmarks.isRefreshing = false
 
-        epoxyRecyclerView.visibility = View.VISIBLE
+        swipeRefreshLayoutBookmarks.visibility = View.VISIBLE
     }
 
 }

--- a/app/src/main/res/layout/fragment_bookmarks.xml
+++ b/app/src/main/res/layout/fragment_bookmarks.xml
@@ -1,20 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/swipeRefreshLayoutBookmarks"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
 
-    <androidx.constraintlayout.widget.ConstraintLayout xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:context=".MainActivity">
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefreshLayoutBookmarks"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
         <com.airbnb.epoxy.EpoxyRecyclerView
             android:id="@+id/epoxyRecyclerView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -22,12 +27,13 @@
             tools:listitem="@layout/view_holder_bookmark"
             tools:visibility="visible" />
 
-        <include
-            android:id="@+id/emptyStateContainer"
-            layout="@layout/include_empty_state"
-            android:visibility="gone"
-            tools:visibility="visible" />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    <include
+        android:id="@+id/emptyStateContainer"
+        layout="@layout/include_empty_state"
+        android:visibility="gone"
+        tools:visibility="visible" />
 
-</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>
+

--- a/app/src/main/res/layout/fragment_bookmarks.xml
+++ b/app/src/main/res/layout/fragment_bookmarks.xml
@@ -1,37 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/swipeRefreshLayoutBookmarks"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    android:layout_height="match_parent">
 
-    <com.airbnb.epoxy.EpoxyRecyclerView
-        android:id="@+id/epoxyRecyclerView"
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:listitem="@layout/view_holder_bookmark"
-        tools:visibility="visible" />
+        tools:context=".MainActivity">
 
-    <include
-        android:id="@+id/emptyStateContainer"
-        layout="@layout/include_empty_state"
-        android:visibility="gone"
-        tools:visibility="visible" />
+        <com.airbnb.epoxy.EpoxyRecyclerView
+            android:id="@+id/epoxyRecyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:listitem="@layout/view_holder_bookmark"
+            tools:visibility="visible" />
 
-    <ProgressBar
-        android:id="@+id/progressBar"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        <include
+            android:id="@+id/emptyStateContainer"
+            layout="@layout/include_empty_state"
+            android:visibility="gone"
+            tools:visibility="visible" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>

--- a/app/src/main/res/layout/fragment_bookmarks.xml
+++ b/app/src/main/res/layout/fragment_bookmarks.xml
@@ -7,14 +7,15 @@
     tools:context=".MainActivity">
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-        android:id="@+id/swipeRefreshLayoutBookmarks"
+        android:id="@+id/bookmarksSwipeRefreshLayout"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible">
 
         <com.airbnb.epoxy.EpoxyRecyclerView
             android:id="@+id/epoxyRecyclerView"
@@ -24,8 +25,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            tools:listitem="@layout/view_holder_bookmark"
-            tools:visibility="visible" />
+            tools:listitem="@layout/view_holder_bookmark" />
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 


### PR DESCRIPTION
I added the `swipeToRefresh` view into the `bookmark` layout, and removed the `progressBar`. Using the same `fetchBookmarks` method, now it's possible to update too.

Fix for #12